### PR TITLE
Fix incorrect xml

### DIFF
--- a/llvm-to-dash.py
+++ b/llvm-to-dash.py
@@ -115,7 +115,7 @@ def add_urls(db, cur):
 
 def add_infoplist():
   name = docset_name.split('.')[0]
-  info = ' <?xml version=\'1.0\' encoding=\'UTF-8\'?>' \
+  info = '<?xml version=\'1.0\' encoding=\'UTF-8\'?>' \
           '<!DOCTYPE plist PUBLIC \'-//Apple//DTD PLIST 1.0//EN\' \'http://www.apple.com/DTDs/PropertyList-1.0.dtd\'> ' \
           '<plist version=\'1.0\'> ' \
           '<dict> ' \


### PR DESCRIPTION
The xml spec states that no whitespace must exist before the first `xml` tag